### PR TITLE
Fix VM-3. add MSP430X toolchain to the OpenVM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -89,8 +89,7 @@ Vagrant.configure(2) do |config|
     sudo apt-get install -y gcc-arm-none-eabi
     sudo apt-get install -y gcc-msp430
     cd $HOME/Downloads
-    wget http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPGCC/latest/exports/msp430-gcc-4.1.0.0_source-full.tar.bz2 &
+    wget http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPGCC/latest/exports/msp430-gcc-support-files-1.191.zip &
     wget http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPGCC/latest/exports/msp430-gcc-4.1.0.0_linux32.tar.bz2
-    
   SHELL
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -95,5 +95,8 @@ Vagrant.configure(2) do |config|
 	sudo mkdir -p /opt/msp430-toolchain && sudo tar xvjf msp430-gcc-4.1.0.0_linux32.tar.bz2 -C /opt/msp430-toolchain --strip-components=1
 	sudo mv msp430-gcc-support-files/include/*.ld /opt/msp430-toolchain/msp430-elf/lib/ldscripts
 	sudo mv msp430-gcc-support-files/include/* /opt/msp430-toolchain/msp430-elf/include
+	sudo rm -rf *	#clean Downloads.dir
+	cd ..
+	echo "export PATH=\$PATH+=/opt/msp430-toolchain/bin" >> .bashrc
   SHELL
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -46,12 +46,12 @@ Vagrant.configure(2) do |config|
   config.vm.provider "virtualbox" do |vb|
     # Display the VirtualBox GUI when booting the machine
     vb.gui = false
-    
+
     # Customize the amount of memory on the VM:
     # vb.memory = "1024"
     vb.customize ["modifyvm", :id, "--usb", "on"]
     vb.customize ["modifyvm", :id, "--usbehci", "on"]
-    
+
   end
   #
   # View the documentation for the provider you are using for more
@@ -70,7 +70,7 @@ Vagrant.configure(2) do |config|
   config.vm.provision "shell", inline: <<-SHELL
     sudo apt-get update
     sudo apt-get install -y git
-    mkdir openwsn 
+    mkdir openwsn
     cd ./openwsn/
     git clone https://github.com/openwsn-berkeley/openwsn-fw.git
     git clone https://github.com/openwsn-berkeley/openwsn-sw.git
@@ -88,5 +88,9 @@ Vagrant.configure(2) do |config|
     sudo apt-get update
     sudo apt-get install -y gcc-arm-none-eabi
     sudo apt-get install -y gcc-msp430
+    cd $HOME/Downloads
+    wget http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPGCC/latest/exports/msp430-gcc-4.1.0.0_source-full.tar.bz2 &
+    wget http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPGCC/latest/exports/msp430-gcc-4.1.0.0_linux32.tar.bz2
+    
   SHELL
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -88,8 +88,12 @@ Vagrant.configure(2) do |config|
     sudo apt-get update
     sudo apt-get install -y gcc-arm-none-eabi
     sudo apt-get install -y gcc-msp430
-    cd $HOME/Downloads
+    cd ../../../../Downloads
     wget http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPGCC/latest/exports/msp430-gcc-support-files-1.191.zip &
     wget http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPGCC/latest/exports/msp430-gcc-4.1.0.0_linux32.tar.bz2
+	unzip msp430-gcc-support-files-1.191.zip &
+	sudo mkdir -p /opt/msp430-toolchain && sudo tar xvjf msp430-gcc-4.1.0.0_linux32.tar.bz2 -C /opt/msp430-toolchain --strip-components=1
+	sudo mv msp430-gcc-support-files/include/*.ld /opt/msp430-toolchain/msp430-elf/lib/ldscripts
+	sudo mv msp430-gcc-support-files/include/* /opt/msp430-toolchain/msp430-elf/include
   SHELL
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -97,7 +97,7 @@ Vagrant.configure(2) do |config|
 	sudo mv msp430-gcc-support-files/include/* /opt/msp430-toolchain/msp430-elf/include
 	sudo rm -rf *	#clean Downloads.dir
 	cd ..
-	echo "export PATH=\$PATH+=/opt/msp430-toolchain/bin" >> .bashrc
+	echo "export PATH=\$PATH:/opt/msp430-toolchain/bin" >> .bashrc
 	sudo apt-get install -y lib32z1
 	sudo apt-get install -y lib32stdc++6
   SHELL

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -98,5 +98,7 @@ Vagrant.configure(2) do |config|
 	sudo rm -rf *	#clean Downloads.dir
 	cd ..
 	echo "export PATH=\$PATH+=/opt/msp430-toolchain/bin" >> .bashrc
+	sudo apt-get install -y lib32z1
+	sudo apt-get install -y lib32stdc++6
   SHELL
 end


### PR DESCRIPTION
Please note that both compilers are still available
-> msp430-gcc (is under /usr/bin)
-> msp430-elf-gcc (is under /opt/msp430-toolchain)
